### PR TITLE
Fix DataTable to scroll within viewport with sticky header

### DIFF
--- a/app/(dashboard)/students/page.tsx
+++ b/app/(dashboard)/students/page.tsx
@@ -76,9 +76,9 @@ export default function StudentsPage() {
     filters.academicYear.size > 0;
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-6 h-full min-h-0">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between shrink-0">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">All Students</h1>
           <p className="text-sm text-gray-500 mt-0.5">
@@ -102,18 +102,20 @@ export default function StudentsPage() {
           <AddStudentButton />
         </div>
       ) : (
-        <DataTable
-          columns={columns}
-          data={students as unknown as StudentRow[]}
-          searchPlaceholder="Search students…"
-          onRowClick={(row) => router.push(`/students/${row._id}`)}
-          toolbar={
-            <StudentsFilterToolbar
-              filters={filters}
-              onFiltersChange={setFilters}
-            />
-          }
-        />
+        <div className="flex-1 min-h-0">
+          <DataTable
+            columns={columns}
+            data={students as unknown as StudentRow[]}
+            searchPlaceholder="Search students…"
+            onRowClick={(row) => router.push(`/students/${row._id}`)}
+            toolbar={
+              <StudentsFilterToolbar
+                filters={filters}
+                onFiltersChange={setFilters}
+              />
+            }
+          />
+        </div>
       )}
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
       >
         <body
-          className="min-h-full bg-background text-foreground"
+          className="h-full bg-background text-foreground"
           suppressHydrationWarning
         >
           {children}

--- a/components/DataTable.tsx
+++ b/components/DataTable.tsx
@@ -79,9 +79,9 @@ export function DataTable<TData, TValue>({
   }, [data.length, table]);
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col gap-4 h-full min-h-0">
       {/* Toolbar: Search + Filters */}
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2 shrink-0">
         <div className="relative w-full sm:max-w-sm">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
           <Input
@@ -98,7 +98,7 @@ export function DataTable<TData, TValue>({
       </div>
 
       {/* Table */}
-      <div className="rounded-md border bg-white">
+      <div className="flex-1 min-h-0 rounded-md border bg-white overflow-auto">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -153,7 +153,7 @@ export function DataTable<TData, TValue>({
       </div>
 
       {/* Pagination */}
-      <div className="flex flex-wrap items-center justify-between gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-4 shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm text-gray-500">Rows per page</span>
           <Select

--- a/components/layout/DashboardWrapper.tsx
+++ b/components/layout/DashboardWrapper.tsx
@@ -38,15 +38,15 @@ export function DashboardWrapper({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="h-screen bg-gray-50 overflow-hidden">
       <Sidebar role={me?.role} email={me?.email} />
       <main
         className={cn(
-          "transition-all duration-300 min-h-screen",
+          "transition-all duration-300 h-full flex flex-col overflow-hidden",
           isCollapsed ? "pl-16" : "pl-[300px]",
         )}
       >
-        <div className="p-6">{children}</div>
+        <div className="flex-1 min-h-0 overflow-auto p-6">{children}</div>
       </main>
     </div>
   );

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -23,7 +23,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
+      className={cn("[&_tr]:border-b sticky top-0 z-10 bg-white", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- Constrain the dashboard layout to viewport height (`h-screen`, `overflow-hidden`) so the table scrolls internally instead of pushing the page
- Convert `DataTable` and its parent containers to flex column layouts with `min-h-0` to allow proper flex shrinking
- Make the table container `overflow-auto` with `flex-1` so it fills available space and scrolls independently
- Add `sticky top-0 z-10 bg-white` to `TableHeader` so column headers stay visible while scrolling
- Change root `body` from `min-h-full` to `h-full` to propagate fixed height down the layout tree

## Testing

- [ ] Verify the DataTable scrolls within its container, not the full page
- [ ] Verify the table header stays pinned at the top while scrolling rows
- [ ] Verify the sidebar remains fixed and does not scroll with table content
- [ ] Verify search bar and filter toolbar remain visible above the table
- [ ] Verify pagination controls remain visible below the table
- [ ] Check responsive behavior on mobile viewport (375px width)
- [ ] Confirm no layout overflow or double scrollbars appear