### PR TITLE
feat: period column formatting with formatBillingPeriod utility

### DIFF
--- a/app/(dashboard)/students/[studentId]/_components/FeesTab.tsx
+++ b/app/(dashboard)/students/[studentId]/_components/FeesTab.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/table";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
+import { formatBillingPeriod } from "@/lib/formatBillingPeriod";
 import { cn } from "@/lib/utils";
 import { CollectFeesDialog } from "./CollectFeesDialog";
 import { FeeDetailDialog } from "./FeeDetailDialog";
@@ -238,7 +239,7 @@ export function FeesTab({ studentId }: FeesTabProps) {
                     {fee.academicYearDoc?.name ?? "—"}
                   </TableCell>
                   <TableCell className="text-sm text-gray-500">
-                    {fee.billingPeriod ?? "—"}
+                    {formatBillingPeriod(fee.billingPeriod)}
                   </TableCell>
                   <TableCell className="text-right text-sm">
                     ৳{fee.originalAmount.toLocaleString()}

--- a/lib/formatBillingPeriod.test.ts
+++ b/lib/formatBillingPeriod.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { formatBillingPeriod } from "./formatBillingPeriod";
+
+describe("formatBillingPeriod", () => {
+  it("formats a standard YYYY-MM string to 'Mon YYYY'", () => {
+    expect(formatBillingPeriod("2025-01")).toBe("Jan 2025");
+    expect(formatBillingPeriod("2025-06")).toBe("Jun 2025");
+    expect(formatBillingPeriod("2025-12")).toBe("Dec 2025");
+  });
+
+  it("returns '—' for undefined", () => {
+    expect(formatBillingPeriod(undefined)).toBe("—");
+  });
+
+  it("returns '—' for null (cast as undefined)", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: testing edge case
+    expect(formatBillingPeriod(null as any)).toBe("—");
+  });
+
+  it("returns '—' for empty string", () => {
+    expect(formatBillingPeriod("")).toBe("—");
+  });
+
+  it("handles January correctly (month index boundary)", () => {
+    expect(formatBillingPeriod("2025-01")).toBe("Jan 2025");
+  });
+
+  it("handles December correctly (month index boundary)", () => {
+    expect(formatBillingPeriod("2025-12")).toBe("Dec 2025");
+  });
+
+  it("handles year boundaries (Dec to Jan transition)", () => {
+    expect(formatBillingPeriod("2024-12")).toBe("Dec 2024");
+    expect(formatBillingPeriod("2025-01")).toBe("Jan 2025");
+  });
+
+  it("formats all 12 months correctly", () => {
+    const expected = [
+      ["2025-01", "Jan 2025"],
+      ["2025-02", "Feb 2025"],
+      ["2025-03", "Mar 2025"],
+      ["2025-04", "Apr 2025"],
+      ["2025-05", "May 2025"],
+      ["2025-06", "Jun 2025"],
+      ["2025-07", "Jul 2025"],
+      ["2025-08", "Aug 2025"],
+      ["2025-09", "Sep 2025"],
+      ["2025-10", "Oct 2025"],
+      ["2025-11", "Nov 2025"],
+      ["2025-12", "Dec 2025"],
+    ];
+
+    for (const [input, output] of expected) {
+      expect(formatBillingPeriod(input)).toBe(output);
+    }
+  });
+
+  it("handles different years", () => {
+    expect(formatBillingPeriod("2020-03")).toBe("Mar 2020");
+    expect(formatBillingPeriod("2030-07")).toBe("Jul 2030");
+  });
+});

--- a/lib/formatBillingPeriod.ts
+++ b/lib/formatBillingPeriod.ts
@@ -1,0 +1,35 @@
+/**
+ * Formats a stored billing period string (YYYY-MM) into a human-readable label.
+ *
+ * @param billingPeriod - A string in "YYYY-MM" format, or undefined/null
+ * @returns A formatted string like "Jan 2025", or "—" for missing values
+ *
+ * @example
+ * formatBillingPeriod("2025-01") // "Jan 2025"
+ * formatBillingPeriod(undefined) // "—"
+ */
+export function formatBillingPeriod(
+  billingPeriod: string | undefined | null,
+): string {
+  if (!billingPeriod) return "—";
+
+  const [yearStr, monthStr] = billingPeriod.split("-");
+  const monthIndex = Number.parseInt(monthStr, 10) - 1;
+
+  const monthNames = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
+  return `${monthNames[monthIndex]} ${yearStr}`;
+}


### PR DESCRIPTION
Closes #8

## Summary
- Add `formatBillingPeriod` pure utility that converts `YYYY-MM` strings to human-readable `Mon YYYY` labels (e.g. `"2025-01"` → `"Jan 2025"`)
- Returns `"—"` for undefined, null, or empty input (handles legacy records safely)
- Update the Period column in the student fees table to use the formatter
- 9 unit tests covering all edge cases (all 12 months, boundaries, null/undefined/empty)

## Test plan
- [x] 9 new unit tests in `lib/formatBillingPeriod.test.ts` — all passing
- [x] 53 total tests passing (no regressions)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] Monthly fees display "Jan 2025" style labels in Period column
- [x] One-time/yearly fees and legacy records show "—"

🤖 Generated with [Claude Code](https://claude.com/claude-code)